### PR TITLE
fix: start services after fresh install and on reboot

### DIFF
--- a/security/pfSense-pkg-crowdsec/files/usr/local/pkg/crowdsec.inc
+++ b/security/pfSense-pkg-crowdsec/files/usr/local/pkg/crowdsec.inc
@@ -209,7 +209,7 @@ function crowdsec_install()
             'enable_agent'                => 'on',
             'enable_lapi'                 => 'on',
             'lapi_host'                   => '127.0.0.1',
-            'lapi_port'                   => '8088',
+            'lapi_port'                   => '8080',
             'agent_log_level'             => 'info',
             'firewall_bouncer_log_level'  => 'info',
             'metrics_port'                => '6060',

--- a/security/pfSense-pkg-crowdsec/files/usr/local/pkg/crowdsec.inc
+++ b/security/pfSense-pkg-crowdsec/files/usr/local/pkg/crowdsec.inc
@@ -199,6 +199,27 @@ function crowdsec_install()
         $crowdsec_conf['db_config']['use_wal'] = true;
         set_yaml_content($crowdsec_conf, CROWDSEC_CONF);
     }
+    // On a fresh install no user config exists yet, so crowdsec_resync_config()
+    // would return early and services would never start — not even after a
+    // reboot, because the rc.d wrapper scripts also read config.xml.
+    // Write the package defaults so that resync (and future boots) work.
+    if (!config_get_path('installedpackages/crowdsec/config/0', [])) {
+        config_set_path('installedpackages/crowdsec/config/0', [
+            'enable_fw_bouncer'           => 'on',
+            'enable_agent'                => 'on',
+            'enable_lapi'                 => 'on',
+            'lapi_host'                   => '127.0.0.1',
+            'lapi_port'                   => '8088',
+            'agent_log_level'             => 'info',
+            'firewall_bouncer_log_level'  => 'info',
+            'metrics_port'                => '6060',
+            'rules_all_interfaces'        => 'on',
+            'enable_rule_v4'              => 'on',
+            'enable_rule_v6'              => 'on',
+        ]);
+        write_config('pfsense_crowdsec: write defaults on first install');
+    }
+    crowdsec_resync_config();
 }
 
 /**


### PR DESCRIPTION
On a fresh install, crowdsec_resync_config() returned early because no user config existed in config.xml yet. The rc.d wrapper scripts have the same dependency, so services also failed to start after a reboot until the user manually saved settings via the web UI.

Write package defaults to config.xml at the end of crowdsec_install() so that crowdsec_resync_config() runs fully on first install, and the rc.d wrappers find the expected settings on every subsequent boot.